### PR TITLE
fix path resolving

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -32,6 +32,10 @@ const DEVELOPMENT_CONFIG = {
     }
   },
 
+  output: {
+    publicPath: '/'
+  },
+
   plugins: [
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NamedModulesPlugin(),


### PR DESCRIPTION
when we have nested routes e.g  `auth/login ` we will get 404
```http://localhost:9001/auth/vendor.js Failed to load resource: the server responded with a status of 404 (Not Found)
http://localhost:9001/auth/client.js Failed to load resource: the server responded with a status of 404 (Not Found)
```
this pr fixing this issue